### PR TITLE
Fixed APStream stopAt comparison

### DIFF
--- a/examples/Congestion/SmallNetwork3/config.xml
+++ b/examples/Congestion/SmallNetwork3/config.xml
@@ -3,19 +3,19 @@
     <ConnectionSets>
         <ConnectionSet id="all">
             <SimTime t="0">
-                <Connection src="111_Layer1" dst="131_Layer1" qosCube="1"/>
-                <Connection src="112_Layer1" dst="131_Layer1" qosCube="1"/>
-                <Connection src="113_Layer1" dst="131_Layer1" qosCube="1"/>
-                <Connection src="114_Layer1" dst="131_Layer1" qosCube="1"/>
-                <Connection src="115_Layer1" dst="131_Layer1" qosCube="1"/>
+                <Connection src="111_Layer1" dst="131_Layer1" qosReq="1"/>
+                <Connection src="112_Layer1" dst="131_Layer1" qosReq="1"/>
+                <Connection src="113_Layer1" dst="131_Layer1" qosReq="1"/>
+                <Connection src="114_Layer1" dst="131_Layer1" qosReq="1"/>
+                <Connection src="115_Layer1" dst="131_Layer1" qosReq="1"/>
 
-                <Connection src="131_Layer1" dst="141_Layer1" qosCube="1"/>
+                <Connection src="131_Layer1" dst="141_Layer1" qosReq="1"/>
 				
-                <Connection src="141_Layer1" dst="121_Layer1" qosCube="1"/>
-                <Connection src="141_Layer1" dst="122_Layer1" qosCube="1"/>
-                <Connection src="141_Layer1" dst="123_Layer1" qosCube="1"/>
-                <Connection src="141_Layer1" dst="124_Layer1" qosCube="1"/>
-                <Connection src="141_Layer1" dst="125_Layer1" qosCube="1"/>
+                <Connection src="141_Layer1" dst="121_Layer1" qosReq="1"/>
+                <Connection src="141_Layer1" dst="122_Layer1" qosReq="1"/>
+                <Connection src="141_Layer1" dst="123_Layer1" qosReq="1"/>
+                <Connection src="141_Layer1" dst="124_Layer1" qosReq="1"/>
+                <Connection src="141_Layer1" dst="125_Layer1" qosReq="1"/>
             </SimTime>
         </ConnectionSet>
     </ConnectionSets>

--- a/examples/Congestion/SmallNetwork3/omnetpp.ini
+++ b/examples/Congestion/SmallNetwork3/omnetpp.ini
@@ -19,18 +19,6 @@ debug-on-errors = true
 **.host24.applicationProcess1.apName = "App24"
 **.host25.applicationProcess1.apName = "App25"
 
-**.host11.applicationProcess1.applicationEntity.iae.aeName = "Stream11"
-**.host12.applicationProcess1.applicationEntity.iae.aeName = "Stream12"
-**.host13.applicationProcess1.applicationEntity.iae.aeName = "Stream13"
-**.host14.applicationProcess1.applicationEntity.iae.aeName = "Stream14"
-**.host15.applicationProcess1.applicationEntity.iae.aeName = "Stream15"
-
-**.host21.applicationProcess1.applicationEntity.iae.aeName = "Stream21"
-**.host22.applicationProcess1.applicationEntity.iae.aeName = "Stream22"
-**.host23.applicationProcess1.applicationEntity.iae.aeName = "Stream23"
-**.host24.applicationProcess1.applicationEntity.iae.aeName = "Stream24"
-**.host25.applicationProcess1.applicationEntity.iae.aeName = "Stream25"
-
 #Static addressing: lower IPC layer
 **.host11.ipcProcess0.ipcAddress = "011"
 **.host12.ipcProcess0.ipcAddress = "012"
@@ -144,8 +132,10 @@ debug-on-errors = true
 **.ra.qoscubesData = xmldoc("config.xml", "Configuration/QoSCubesSet")
 
 # flows to allocate at the beginning
-#**.ra.preallocation = \
-#    xmldoc("config.xml", "Configuration/ConnectionSets/ConnectionSet[@id='all']/")
+**.ra.preallocation = \
+    xmldoc("config.xml", "Configuration/ConnectionSets/ConnectionSet[@id='all']/")
+**.ipcProcess1.**.ra.qosReqData = xmldoc("qosreq.xml", "QoSReqSet")
+**.router*.**ra.qosReqData = xmldoc("qosreq.xml", "QoSReqSet")
 
 #Enrollment
 **.router2.**.enrollment.isSelfEnrolled = true
@@ -182,8 +172,6 @@ fingerprint = "4271-9ddd"
 **.host11.applicationProcess1.apInst.startAt = 2s
 **.host11.applicationProcess1.apInst.interval = 0.002s#0.001s,
 **.host11.applicationProcess1.apInst.stopAt = 162s
-**.host11.applicationProcess1.AEMonitor.**.iae.size = 536B
-**.host11.applicationProcess1.AEMonitor.**.iae.forceOrder = true
 **.host11.ipcProcess1.efcp.efcp.txControlPolicy = "DTCPTxControlPolicyTCPTahoe"
 **.host11.ipcProcess1.efcp.efcp.rttEstimatorPolicy = "DTPRTTEstimatorPolicyTCP"
 **.host11.ipcProcess1.efcp.efcp.senderAckPolicy = "DTCPSenderAckPolicyTCP"

--- a/examples/Congestion/SmallNetwork3/omnetpp.ini
+++ b/examples/Congestion/SmallNetwork3/omnetpp.ini
@@ -171,9 +171,6 @@ fingerprint = "4271-9ddd"
 **.host11.applicationProcess1.apInst.startAt = 2s
 **.host11.applicationProcess1.apInst.interval = 0.002s#0.001s,
 **.host11.applicationProcess1.apInst.stopAt = 60s
-**.host11.ipcProcess1.efcp.efcp.txControlPolicy = "DTCPTxControlPolicyTCPTahoe"
-**.host11.ipcProcess1.efcp.efcp.rttEstimatorPolicy = "DTPRTTEstimatorPolicyTCP"
-**.host11.ipcProcess1.efcp.efcp.senderAckPolicy = "DTCPSenderAckPolicyTCP"
 **.host11.ipcProcess1.efcp.efcp.maxClosedWinQueLen = 200#50000
 
 # Upstream Notification
@@ -184,9 +181,6 @@ fingerprint = "4271-9ddd"
 **.router1.ipcProcess0[5].relayAndMux.defaultMaxQLength = 175#${ 6,  ,  ,  ,  ,  , 175}
 **.router1.ipcProcess0[5].relayAndMux.defaultThreshQLength = 175#${ 6,  ,  ,  ,  ,  , 175}
 **.router1.ipcProcess0[5].relayAndMux.maxQPolicyName = "UpstreamNotifier"
-**.router1.ipcProcess0[5].efcp.efcp.txControlPolicy = "DTCPTxControlPolicyTCPTahoe"
-**.router1.ipcProcess0[5].efcp.efcp.rttEstimatorPolicy = "RTTEstimatorPolicyTCP"
-**.router1.ipcProcess0[5].efcp.efcp.senderAckPolicy = "DTCPSenderAckPolicyTCP"
 **.router1.ipcProcess0[5].efcp.efcp.maxClosedWinQueLen = 25#${ 6,  ,  ,  ,  ,  , 25}
 # End; Upstream Notification
 

--- a/examples/Congestion/SmallNetwork3/omnetpp.ini
+++ b/examples/Congestion/SmallNetwork3/omnetpp.ini
@@ -1,5 +1,5 @@
 [General]
-
+network = SmallNetworkAgg
 sim-time-limit = 62s
 seed-set = ${runnumber}
 **.vector-recording = true
@@ -135,7 +135,7 @@ debug-on-errors = true
 **.ra.preallocation = \
     xmldoc("config.xml", "Configuration/ConnectionSets/ConnectionSet[@id='all']/")
 **.ipcProcess1.**.ra.qosReqData = xmldoc("qosreq.xml", "QoSReqSet")
-**.router*.**ra.qosReqData = xmldoc("qosreq.xml", "QoSReqSet")
+**.router*.relayIpc.**.qosReqData = xmldoc("qosreq.xml", "QoSReqSet")
 
 #Enrollment
 **.router2.**.enrollment.isSelfEnrolled = true
@@ -159,7 +159,6 @@ debug-on-errors = true
 
 
 [Config Aggregation]
-network = SmallNetworkAgg
 SmallNetworkAgg.ldelay = 37.5ms#${1.25ms, 6.25ms, 12.5ms, 18.75ms, 25ms, 31.25ms, 37.5ms}
 fingerprint = "4271-9ddd"
 

--- a/examples/Congestion/SmallNetwork3/omnetpp.ini
+++ b/examples/Congestion/SmallNetwork3/omnetpp.ini
@@ -170,7 +170,7 @@ fingerprint = "4271-9ddd"
 
 **.host11.applicationProcess1.apInst.startAt = 2s
 **.host11.applicationProcess1.apInst.interval = 0.002s#0.001s,
-**.host11.applicationProcess1.apInst.stopAt = 162s
+**.host11.applicationProcess1.apInst.stopAt = 60s
 **.host11.ipcProcess1.efcp.efcp.txControlPolicy = "DTCPTxControlPolicyTCPTahoe"
 **.host11.ipcProcess1.efcp.efcp.rttEstimatorPolicy = "DTPRTTEstimatorPolicyTCP"
 **.host11.ipcProcess1.efcp.efcp.senderAckPolicy = "DTCPSenderAckPolicyTCP"

--- a/examples/Congestion/SmallNetwork3/qosreq.xml
+++ b/examples/Congestion/SmallNetwork3/qosreq.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+	<QoSReqSet>	
+		<QosReq id="1"> 
+			<Delay>10</Delay>	
+		</QosReq>
+		<QosReq id="2"> 
+			<Delay>100</Delay>	
+		</QosReq>
+		<QosReq id="3"> 
+			<Delay>1000</Delay>	
+		</QosReq>
+	</QoSReqSet>
+	

--- a/src/DAF/AP/APStream/APStream.cc
+++ b/src/DAF/AP/APStream/APStream.cc
@@ -45,7 +45,7 @@ void APStream::handleMessage(cMessage *msg) {
             a_close(conID);
         }
         else if (!strcmp(msg->getName(), "stream")){
-            if (par("stopAt").doubleValue() < (simTime().dbl()+1)) {
+            if ((simTime().dbl()+1) < par("stopAt").doubleValue()) {
                 object_t obj;
                 obj.objectName = "stream";
                 obj.objectVal = (cObject*)"tmp";


### PR DESCRIPTION
Hi all,

The APStream have the same issue than APPing that prevent it to stream until the stopAt parameter have being reached. After this patch it worked well here.