### PR TITLE
Changes in score counting in QoSCubes when less is better

### DIFF
--- a/examples/Congestion/SmallNetwork3/config.xml
+++ b/examples/Congestion/SmallNetwork3/config.xml
@@ -423,6 +423,8 @@
             <CostTime>0</CostTime>
             <CostBits>0</CostBits>
             <ATime>0</ATime>
+            <WinOn>1</WinOn>
+            <RateOn>0</RateOn>
             <EFCPPolicySet>
 				<SenderAck>SenderAckPolicyTCP</SenderAck>
 				<RTTEstimator>RTTEstimatorPolicyTCP</RTTEstimator>

--- a/policies/DIF/EFCP/DTCP/TxControl/TxControlPolicyTCPTahoe/TxControlPolicyTCPTahoe.ned
+++ b/policies/DIF/EFCP/DTCP/TxControl/TxControlPolicyTCPTahoe/TxControlPolicyTCPTahoe.ned
@@ -25,6 +25,6 @@ simple TxControlPolicyTCPTahoe
         string policyName = "TCP Tahoe";
         int packetSize = default(536);
 
-        @signal[TCP_Tahoe_CWND](type=int);
+        @signal[TCP_Tahoe_CWND](type=double);
         @statistic[TCP-Tahoe-CWND](title="TCP Tahoe CWND"; source=TCP_Tahoe_CWND; record=vector, mean);
 }

--- a/policies/DIF/FA/NewFlowRequest/MinComparer/MinComparer.cc
+++ b/policies/DIF/FA/NewFlowRequest/MinComparer/MinComparer.cc
@@ -65,13 +65,13 @@ bool MinComparer::isFeasibility(const QoSReq requirements, const QoSCube cube) c
     if(!cube.isForceOrder() && requirements.isForceOrder())
         return false;
 
-    if (requirements.getMaxAllowGap() != VAL_QOSPARDONOTCARE && requirements.getMaxAllowGap() > cube.getMaxAllowGap())
+    if (requirements.getMaxAllowGap() != VAL_QOSPARDONOTCARE && requirements.getMaxAllowGap() < cube.getMaxAllowGap())
         return false;
 
     if (requirements.getDelay() != VAL_QOSPARDONOTCARE && requirements.getDelay() < cube.getDelay())
         return false;
 
-    if (requirements.getJitter() != VAL_QOSPARDONOTCARE && requirements.getJitter() > cube.getJitter())
+    if (requirements.getJitter() != VAL_QOSPARDONOTCARE && requirements.getJitter() < cube.getJitter())
         return false;
 
     if (requirements.getCostTime() != VAL_QOSPARDONOTCARE && requirements.getCostTime() < cube.getCostTime())

--- a/policies/DIF/FA/NewFlowRequest/ScoreComparer/ScoreComparer.cc
+++ b/policies/DIF/FA/NewFlowRequest/ScoreComparer/ScoreComparer.cc
@@ -47,10 +47,10 @@ short ScoreComparer::countFeasibilityScore(const QoSReq& requirements, const QoS
         (requirements.getBurstDuration() <= cube.getBurstDuration()) ? score++ : score--;
 
     if (requirements.getUndetectedBitErr() != VAL_QOSPARDONOTCARE)
-        (requirements.getUndetectedBitErr() <= cube.getUndetectedBitErr()) ? score++ : score--;
+        (requirements.getUndetectedBitErr() >= cube.getUndetectedBitErr()) ? score++ : score--;
 
     if (requirements.getPduDropProbability() != VAL_QOSPARDONOTCARE)
-        (requirements.getPduDropProbability() <= cube.getPduDropProbability()) ? score++ : score--;
+        (requirements.getPduDropProbability() >= cube.getPduDropProbability()) ? score++ : score--;
 
     if (requirements.getMaxSduSize() != VAL_QOSPARDONOTCARE)
         (requirements.getMaxSduSize() <= cube.getMaxSduSize()) ? score++ : score--;
@@ -62,19 +62,19 @@ short ScoreComparer::countFeasibilityScore(const QoSReq& requirements, const QoS
     (requirements.isForceOrder() == cube.isForceOrder()) ? score++ : score--;
 
     if (requirements.getMaxAllowGap() != VAL_QOSPARDONOTCARE)
-        (requirements.getMaxAllowGap() <= cube.getMaxAllowGap()) ? score++ : score--;
+        (requirements.getMaxAllowGap() >= cube.getMaxAllowGap()) ? score++ : score--;
 
     if (requirements.getDelay() != VAL_QOSPARDONOTCARE)
-        (requirements.getDelay() <= cube.getDelay()) ? score++ : score--;
+        (requirements.getDelay() >= cube.getDelay()) ? score++ : score--;
 
     if (requirements.getJitter() != VAL_QOSPARDONOTCARE)
-        (requirements.getJitter() <= cube.getJitter()) ? score++ : score--;
+        (requirements.getJitter() >= cube.getJitter()) ? score++ : score--;
 
     if (requirements.getCostTime() != VAL_QOSPARDONOTCARE)
-        (requirements.getCostTime() <= cube.getCostTime()) ? score++ : score--;
+        (requirements.getCostTime() >= cube.getCostTime()) ? score++ : score--;
 
     if (requirements.getCostBits() != VAL_QOSPARDONOTCARE)
-        (requirements.getCostBits() <= cube.getCostBits()) ? score++ : score--;
+        (requirements.getCostBits() >= cube.getCostBits()) ? score++ : score--;
 
     return score;
 }


### PR DESCRIPTION
I suggest some changes in ScoreComparer FA policy.
Basically, this affect the score counting for that cases where less is better. In the original code greater is always better, but in fact, this is not the truth.

Example:
(requirements.getUndetectedBitErr() >= cube.getUndetectedBitErr()) ? score++ : score--;
Here, the QoSCube should provide a undetected bit error rate inferior than that acceptable by the application to met their requirements. Less undetected bit error is better.

The same explanation for:
requirements.getPduDropProbability() >= cube.getPduDropProbability()
requirements.getMaxAllowGap() >= cube.getMaxAllowGap()
requirements.getDelay() >= cube.getDelay()
requirements.getJitter() >= cube.getJitter()
requirements.getCostTime() >= cube.getCostTime()
requirements.getCostBits() >= cube.getCostBits()

Kleber
