### PR TITLE
Add OMNeT++ 6 preview support.

### DIFF
--- a/policies/DIF/EFCP/DTCP/TxControl/TxControlPolicyTCPTahoe/TxControlPolicyTCPTahoe.cc
+++ b/policies/DIF/EFCP/DTCP/TxControl/TxControlPolicyTCPTahoe/TxControlPolicyTCPTahoe.cc
@@ -40,7 +40,7 @@ void TxControlPolicyTCPTahoe::initialize(int step)
     if(step == 0){
         sigStatTCPTahoeCWND = registerSignal("TCP_Tahoe_CWND");
     }
-    packetSize = par("packetSize").longValue();
+    packetSize = par("packetSize");
     ackPolicy = check_and_cast<SenderAckPolicyTCP *>(getModuleByPath("^.senderAckPolicy"));//^.^.efcp
 }
 

--- a/policies/DIF/FA/MultilevelQoS/QoSIdComparer/QoSIdComparer.cc
+++ b/policies/DIF/FA/MultilevelQoS/QoSIdComparer/QoSIdComparer.cc
@@ -25,8 +25,8 @@
 Define_Module(QoSIdComparer);
 
 void QoSIdComparer::initialize() {
-    mHops = par("maxHops").longValue();
-    mlBandw = par("mulBandw").longValue();
+    mHops = par("maxHops");
+    mlBandw = par("mulBandw");
     setPolicyDisplayString(this);
 }
 

--- a/policies/DIF/FA/MultilevelQoS/QoSMinComparer/QoSMinComparer.cc
+++ b/policies/DIF/FA/MultilevelQoS/QoSMinComparer/QoSMinComparer.cc
@@ -25,8 +25,8 @@
 Define_Module(QoSMinComparer);
 
 void QoSMinComparer::initialize() {
-    mHops = par("maxHops").longValue();
-    mlBandw = par("mulBandw").longValue();
+    mHops = par("maxHops");
+    mlBandw = par("mulBandw");
     setPolicyDisplayString(this);
 }
 

--- a/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosFabric.cc
+++ b/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosFabric.cc
@@ -196,10 +196,10 @@ void GRE_ClosFabric::onPolicyInit() {
     fwd = getRINAModule<Clos1 *>(this, 2,
             { MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD });
 
-    f = par("fabrics").longValue();
-    p = par("pods").longValue();
-    s = par("spines").longValue();
-    t = par("tors").longValue();
+    f = par("fabrics");
+    p = par("pods");
+    s = par("spines");
+    t = par("tors");
 
     rawAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
     dif = getModuleByPath("^.^")->par("difName").stringValue();

--- a/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosSpine.cc
+++ b/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosSpine.cc
@@ -97,10 +97,10 @@ void GRE_ClosSpine::onPolicyInit(){
     rt = getRINAModule<RoutingDumb *>(this, 2, {MOD_POL_ROUTING});
     fwd = getRINAModule<Clos2 *>(this, 2, {MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD});
 
-    f = par("fabrics").longValue();
-    p = par("pods").longValue();
-    s = par("spines").longValue();
-    t = par("tors").longValue();
+    f = par("fabrics");
+    p = par("pods");
+    s = par("spines");
+    t = par("tors");
 
     rawAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
     dif = getModuleByPath("^.^")->par("difName").stringValue();

--- a/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosToR.cc
+++ b/policies/DIF/RA/PDUFG/GRE/Centralized/GRE_ClosToR.cc
@@ -195,10 +195,10 @@ void GRE_ClosToR::onPolicyInit() {
     fwd = getRINAModule<Clos0 *>(this, 2,
             { MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD });
 
-    f = par("fabrics").longValue();
-    p = par("pods").longValue();
-    s = par("spines").longValue();
-    t = par("tors").longValue();
+    f = par("fabrics");
+    p = par("pods");
+    s = par("spines");
+    t = par("tors");
 
     rawAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
     dif = getModuleByPath("^.^")->par("difName").stringValue();

--- a/policies/DIF/RA/PDUFG/GRE/ClosRouting/GRE_ClosR.cc
+++ b/policies/DIF/RA/PDUFG/GRE/ClosRouting/GRE_ClosR.cc
@@ -56,10 +56,10 @@ void GRE_ClosR::removedFlow(const Address &addr, const QoSCube& qos, RMTPort * p
 
 // Called after initialize
 void GRE_ClosR::onPolicyInit(){
-    f = par("fabrics").longValue();
-    p = par("pods").longValue();
-    s = par("spines").longValue();
-    t = par("tors").longValue();
+    f = par("fabrics");
+    p = par("pods");
+    s = par("spines");
+    t = par("tors");
 
     //Set Forwarding policy
     fwd = getRINAModule<GREFWD *>(this, 2, {MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD});

--- a/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos0S.cc
+++ b/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos0S.cc
@@ -65,7 +65,7 @@ void GRE_ClosS0::routingUpdated(){}
 
 // Called after initialize
 void GRE_ClosS0::onPolicyInit(){
-    f = par("fabrics").longValue();
+    f = par("fabrics");
 
     //Set Forwarding policy
     fwd = getRINAModule<Clos0 *>(this, 2, {MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD});

--- a/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos1S.cc
+++ b/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos1S.cc
@@ -75,9 +75,9 @@ void GRE_ClosS1::routingUpdated(){}
 
 // Called after initialize
 void GRE_ClosS1::onPolicyInit(){
-    f = par("spineS").longValue();
-    t = par("TEs").longValue();
-    s = par("spines").longValue();
+    f = par("spineS");
+    t = par("TEs");
+    s = par("spines");
 
     //Set Forwarding policy
     fwd = getRINAModule<Clos1 *>(this, 2, {MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD});

--- a/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos2S.cc
+++ b/policies/DIF/RA/PDUFG/GRE/ClosStatic/GRE_Clos2S.cc
@@ -59,8 +59,8 @@ void GRE_ClosS2::routingUpdated(){}
 
 // Called after initialize
 void GRE_ClosS2::onPolicyInit(){
-    p = par("pods").longValue();
-    s = par("spineS").longValue();
+    p = par("pods");
+    s = par("spineS");
 
     //Set Forwarding policy
     fwd = getRINAModule<Clos2 *>(this, 2, {MOD_RELAYANDMUX, MOD_POL_RMT_PDUFWD});

--- a/policies/DIF/RA/PDUFG/IQoSAwareMEntries/IQoSAwareMEntries.cc
+++ b/policies/DIF/RA/PDUFG/IQoSAwareMEntries/IQoSAwareMEntries.cc
@@ -128,7 +128,7 @@ void IQoSAwareMEntries::onPolicyInit(){
     mType infMetric = par("infinite");
     rt->setInfinite(infMetric);
 
-    maxLat = par("maxLat").longValue();
+    maxLat = par("maxLat");
 
     string myAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
 

--- a/policies/DIF/RA/PDUFG/LatGenerator/LatGenerator.cc
+++ b/policies/DIF/RA/PDUFG/LatGenerator/LatGenerator.cc
@@ -44,16 +44,16 @@ bool portMetric::operator < (const portMetric &other) const {
 void LatGenerator::insertedFlow(const Address &addr, const QoSCube &qos, RMTPort * port){
     std::string dst = addr.getIpcAddress().getName();
 
-    unsigned short metric = qos.getDelay()/par("redLinkCost").longValue();
+    unsigned short metric = qos.getDelay() / static_cast<long>(par("redLinkCost"));
 
-    if(metric < par("minLinkCost").longValue()) {
-        metric = par("minLinkCost").longValue();
-    } else if(metric > par("maxLinkCost").longValue()) {
-        metric = par("maxLinkCost").longValue();
+    if(metric < static_cast<long>(par("minLinkCost"))) {
+        metric = par("minLinkCost");
+    } else if(metric > static_cast<long>(par("maxLinkCost"))) {
+        metric = par("maxLinkCost");
     }
 
     if(qos.getQosId() == qos.MANAGEMENT.getQosId() || qos.getQosId() == VAL_UNDEF_QOSID) {
-        metric = par("maxLinkCost").longValue();
+        metric = par("maxLinkCost");
     }
 
     neighbours[dst].insert(portMetric(port, metric));
@@ -79,7 +79,7 @@ void LatGenerator::removedFlow(const Address &addr, const QoSCube& qos, RMTPort 
         neighbours.erase(dst);
         routingUpdated();
     } else {
-        unsigned short min = par("maxLinkCost").longValue();
+        unsigned short min = par("maxLinkCost");
         for(portMetric mt : neighbours[dst]) {
             if(min >= mt.metric) { min = mt.metric; }
         }

--- a/policies/DIF/RA/PDUFG/LatencySingle1Entry/LatencySingle1Entry.cc
+++ b/policies/DIF/RA/PDUFG/LatencySingle1Entry/LatencySingle1Entry.cc
@@ -37,16 +37,16 @@ bool portMetric::operator < (const portMetric &other) const {
 void LatencySingle1Entry::insertedFlow(const Address &addr, const QoSCube &qos, RMTPort * port){
     string dst = addr.getIpcAddress().getName();
 
-    mType metric = qos.getDelay()/par("redLinkCost").longValue();
+    mType metric = qos.getDelay() / static_cast<long>(par("redLinkCost"));
 
-    if(metric < par("minLinkCost").longValue()) {
-        metric = par("minLinkCost").longValue();
-    } else if(metric > par("maxLinkCost").longValue()) {
-        metric = par("maxLinkCost").longValue();
+    if(metric < static_cast<long>(par("minLinkCost"))) {
+        metric = par("minLinkCost");
+    } else if(metric > static_cast<long>(par("maxLinkCost"))) {
+        metric = par("maxLinkCost");
     }
 
     if(qos.getQosId() == qos.MANAGEMENT.getQosId() || qos.getQosId() == VAL_UNDEF_QOSID) {
-        metric = par("maxLinkCost").longValue();
+        metric = par("maxLinkCost");
     }
 
     neighbours[dst].insert(portMetric(port, metric));
@@ -72,7 +72,7 @@ void LatencySingle1Entry::removedFlow(const Address &addr, const QoSCube& qos, R
         neighbours.erase(dst);
         routingUpdated();
     } else {
-        unsigned short min = par("maxLinkCost").longValue();
+        unsigned short min = par("maxLinkCost");
         for(portMetric mt : neighbours[dst]) {
             if(min >= mt.metric) { min = mt.metric; }
         }

--- a/policies/DIF/RA/PDUFG/LatencySingleMEntries/LatencySingleMEntries.cc
+++ b/policies/DIF/RA/PDUFG/LatencySingleMEntries/LatencySingleMEntries.cc
@@ -37,16 +37,16 @@ bool portMetric::operator < (const portMetric &other) const {
 void LatencySingleMEntries::insertedFlow(const Address &addr, const QoSCube &qos, RMTPort * port){
     string dst = addr.getIpcAddress().getName();
 
-    mType metric = qos.getDelay()/par("redLinkCost").longValue();
+    mType metric = qos.getDelay() / static_cast<long>(par("redLinkCost"));
 
-    if(metric < par("minLinkCost").longValue()) {
-        metric = par("minLinkCost").longValue();
-    } else if(metric > par("maxLinkCost").longValue()) {
-        metric = par("maxLinkCost").longValue();
+    if(metric < static_cast<long>(par("minLinkCost"))) {
+        metric = par("minLinkCost");
+    } else if(metric > static_cast<long>(par("maxLinkCost"))) {
+        metric = par("maxLinkCost");
     }
 
     if(qos.getQosId() == qos.MANAGEMENT.getQosId() || qos.getQosId() == VAL_UNDEF_QOSID) {
-        metric = par("maxLinkCost").longValue();
+        metric = par("maxLinkCost");
     }
 
     neighbours[dst].insert(portMetric(port, metric));
@@ -72,7 +72,7 @@ void LatencySingleMEntries::removedFlow(const Address &addr, const QoSCube& qos,
         neighbours.erase(dst);
         routingUpdated();
     } else {
-        unsigned short min = par("maxLinkCost").longValue();
+        unsigned short min = par("maxLinkCost");
         for(portMetric mt : neighbours[dst]) {
             if(min >= mt.metric) { min = mt.metric; }
         }

--- a/policies/DIF/RA/PDUFG/PLQoSAwareMEntries/PLQoSAwareMEntries.cc
+++ b/policies/DIF/RA/PDUFG/PLQoSAwareMEntries/PLQoSAwareMEntries.cc
@@ -137,7 +137,7 @@ void PLQoSAwareMEntries::onPolicyInit(){
     mType infMetric = par("infinite");
     rt->setInfinite(infMetric);
 
-    maxLat = par("maxLat").longValue();
+    maxLat = par("maxLat");
 
     string myAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
 

--- a/policies/DIF/RA/PDUFG/QoSAwareMEntries/QoSAwareMEntries.cc
+++ b/policies/DIF/RA/PDUFG/QoSAwareMEntries/QoSAwareMEntries.cc
@@ -125,7 +125,7 @@ void QoSAwareMEntries::onPolicyInit(){
     mType infMetric = par("infinite");
     rt->setInfinite(infMetric);
 
-    maxLat = par("maxLat").longValue();
+    maxLat = par("maxLat");
 
     string myAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
 

--- a/policies/DIF/RA/PDUFG/SimpleLatOrHopMEntries/SimpleLatOrHopMEntries.cc
+++ b/policies/DIF/RA/PDUFG/SimpleLatOrHopMEntries/SimpleLatOrHopMEntries.cc
@@ -98,7 +98,7 @@ void SimpleLatOrHopMEntries::onPolicyInit(){
     mType infMetric = par("infinite");
     rt->setInfinite(infMetric);
 
-    maxLat = par("maxLat").longValue();
+    maxLat = par("maxLat");
 
     string myAddr = getModuleByPath("^.^")->par("ipcAddress").stringValue();
 

--- a/policies/DIF/RA/QueueAlloc/QueuePerNQoSxPLen/QueuePerNQoSxPLen.cc
+++ b/policies/DIF/RA/QueueAlloc/QueuePerNQoSxPLen/QueuePerNQoSxPLen.cc
@@ -47,6 +47,6 @@ void QueuePerNQoSxPLen::onNM1PortInit(RMTPort* port) {
 
 
 void QueuePerNQoSxPLen::onPolicyInit() {
-    maxHCount = par("maxHCount").longValue();
+    maxHCount = par("maxHCount");
     if(maxHCount <= 0) { maxHCount = 1; }
 }

--- a/policies/DIF/RA/QueueIDGen/IDPerNQoSxPLen/IDPerNQoSxPLen.cc
+++ b/policies/DIF/RA/QueueIDGen/IDPerNQoSxPLen/IDPerNQoSxPLen.cc
@@ -50,7 +50,7 @@ string IDPerNQoSxPLen::generateInputQueueID(PDU* pdu)
 
 
 void IDPerNQoSxPLen::initialize() {
-    maxHCount = par("maxHCount").longValue();
+    maxHCount = par("maxHCount");
     if(maxHCount <= 0) { maxHCount = 1; }
 
     cXMLElement* Xml = NULL;

--- a/policies/DIF/RMT/Monitor/IterativeStopMonitor/IterativeStopMonitor.cc
+++ b/policies/DIF/RMT/Monitor/IterativeStopMonitor/IterativeStopMonitor.cc
@@ -31,8 +31,8 @@ Define_Module(IterativeStopMonitor);
 
 void IterativeStopMonitor::onPolicyInit(){
     schedMod= getRINAModule<IterativeScheduling*>(this, 1, {MOD_POL_RMT_SCHEDULER});
-    stopAt = par("stopAt").longValue();
-    restartAt = par("restartAt").longValue();
+    stopAt = par("stopAt");
+    restartAt = par("restartAt");
 
     stopSignal = registerSignal(SIG_EFCP_StopSending);
     startSignal = registerSignal(SIG_EFCP_StartSending);

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_DL_Drop/MM_DL_Drop.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_DL_Drop/MM_DL_Drop.cc
@@ -23,7 +23,7 @@ Define_Module(MM_DL_Drop);
 
 void MM_DL_Drop::initialize() {
 
-    defaultThreshold = par("defThreshold").longValue();
+    defaultThreshold = par("defThreshold");
     if(defaultThreshold <= 0) { error("Error at DL_Drop. defThreshold must be >0!"); }
 
     cXMLElement* Xml = NULL;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_DL_Out/MM_DL_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_DL_Out/MM_DL_Out.cc
@@ -22,7 +22,7 @@ namespace MM_DL_Out {
 Define_Module(MM_DL_Out);
 
 void MM_DL_Out::initialize() {
-    defaultPriority = par("defPriority").longValue();
+    defaultPriority = par("defPriority");
     if(defaultPriority < 0) { error("Error at DL_Out. defPriority must be >=0!"); }
 
     maxPriority = defaultPriority;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_DQ_Drop/MM_DQ_Drop.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_DQ_Drop/MM_DQ_Drop.cc
@@ -39,7 +39,7 @@ QueueConfig::QueueConfig(string _id, int _absThreshold){
 
 void MM_DQ_Drop::initialize() {
 
-    defaultThreshold = par("defaultThreshold").longValue();
+    defaultThreshold = par("defaultThreshold");
     if(defaultThreshold < 0) { error("Error at DL_Drop. defThreshold must be >= 0!"); }
 
     cXMLElement* Xml = NULL;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_DQ_Out/MM_DQ_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_DQ_Out/MM_DQ_Out.cc
@@ -49,10 +49,10 @@ QueueData::QueueData(){
 
 
 void MM_DQ_Out::initialize() {
-    defaultPriority = par("defPriority").longValue();
+    defaultPriority = par("defPriority");
     if(defaultPriority < 0) { error("Error at eDL_Out. defPriority must be >=0!"); }
 
-    int rateUnit = par("rateUnit").longValue();
+    int rateUnit = par("rateUnit");
     if(defaultPriority < 0) { error("Error at eDL_Out. defPriority must be >=0!"); }
 
     maxPriority = defaultPriority;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_PDQ_Drop/MM_PDQ_Drop.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_PDQ_Drop/MM_PDQ_Drop.cc
@@ -41,7 +41,7 @@ QueueConfig::QueueConfig(string _id, int _absThreshold){
 
 void MM_PDQ_Drop::initialize() {
 
-    defaultThreshold = par("defaultThreshold").longValue();
+    defaultThreshold = par("defaultThreshold");
     if(defaultThreshold < 0) { error("Error at DL_Drop. defThreshold must be >= 0!"); }
 
     cXMLElement* Xml = NULL;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_P_Out/MM_P_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_P_Out/MM_P_Out.cc
@@ -22,7 +22,7 @@ namespace MM_P_Out {
 Define_Module(MM_P_Out);
 
 void MM_P_Out::initialize() {
-    defaultPriority = par("defPriority").longValue();
+    defaultPriority = par("defPriority");
     if(defaultPriority < 0) { error("Error at P_Out. defPriority must be >=0!"); }
 
 

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_WFQ_Drop/MM_WFQ_Drop.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_WFQ_Drop/MM_WFQ_Drop.cc
@@ -23,7 +23,7 @@ Define_Module(MM_WFQ_Drop);
 
 void MM_WFQ_Drop::initialize() {
 
-    defaultThreshold = par("defThreshold").longValue();
+    defaultThreshold = par("defThreshold");
     if(defaultThreshold <= 0) { error("Error at DL_Drop. defThreshold must be >0!"); }
 
     cXMLElement* Xml = NULL;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_eDL_Drop/MM_eDL_Drop.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_eDL_Drop/MM_eDL_Drop.cc
@@ -23,10 +23,10 @@ Define_Module(MM_eDL_Drop);
 
 void MM_eDL_Drop::initialize() {
 
-    defaultThreshold = par("defThreshold").longValue();
+    defaultThreshold = par("defThreshold");
     if(defaultThreshold <= 0) { error("Error at DL_Drop. defThreshold must be >0!"); }
 
-    defaultAbsThreshold = par("defAbsThreshold").longValue();
+    defaultAbsThreshold = par("defAbsThreshold");
     if(defaultAbsThreshold <= 0) { error("Error at DL_Drop. defAbsThreshold must be >0!"); }
 
     defaultDropProb = par("defDropProb").doubleValue();

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_eDL_Out/MM_eDL_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_eDL_Out/MM_eDL_Out.cc
@@ -22,7 +22,7 @@ namespace MM_eDL_Out {
 Define_Module(MM_eDL_Out);
 
 void MM_eDL_Out::initialize() {
-    defaultPriority = par("defPriority").longValue();
+    defaultPriority = par("defPriority");
     if(defaultPriority < 0) { error("Error at eDL_Out. defPriority must be >=0!"); }
 
     maxPriority = defaultPriority;

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxDelayLimited_Out/MM_maxDelayLimited_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxDelayLimited_Out/MM_maxDelayLimited_Out.cc
@@ -22,7 +22,7 @@ namespace MM_maxDelayLimited_Out {
 Define_Module(MM_maxDelayLimited_Out);
 
 void MM_maxDelayLimited_Out::initialize() {
-    defaultMaxDel = par("defDelay").longValue();
+    defaultMaxDel = par("defDelay");
     if(defaultMaxDel < 0) { error("Error at DL_Out. defDelay must be >=0!"); }
 
 

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxDelay_Out/MM_maxDelay_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxDelay_Out/MM_maxDelay_Out.cc
@@ -22,7 +22,7 @@ namespace MM_maxDelay_Out {
 Define_Module(MM_maxDelay_Out);
 
 void MM_maxDelay_Out::initialize() {
-    defaultMaxDel = par("defDelay").longValue();
+    defaultMaxDel = par("defDelay");
     if(defaultMaxDel < 0) { error("Error at DL_Out. defDelay must be >=0!"); }
 
 

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxPST_Out/MM_maxPST_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxPST_Out/MM_maxPST_Out.cc
@@ -24,8 +24,8 @@ Define_Module(MM_maxPST_Out);
 
 void MM_maxPST_Out::initialize() {
 
-    maxTH = par("maxTH").longValue();
-    margin = par("margin").longValue();
+    maxTH = par("maxTH");
+    margin = par("margin");
 
     cXMLElement* Xml = NULL;
     if (par("data").xmlValue() != NULL && par("data").xmlValue()->hasChildren()){

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxWP_Out/MM_maxWP_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_maxWP_Out/MM_maxWP_Out.cc
@@ -23,7 +23,7 @@ namespace MM_maxWP_Out {
 Define_Module(MM_maxWP_Out);
 
 void MM_maxWP_Out::initialize() {
-    defaultMaxWP = par("defWP").longValue();
+    defaultMaxWP = par("defWP");
     if(defaultMaxWP < 0) { error("Error at DL_Out. defWP must be >=0!"); }
 
 

--- a/policies/DIF/RMT/Monitor/ModularMonitor/MM_psDQ_Out/MM_psDQ_Out.cc
+++ b/policies/DIF/RMT/Monitor/ModularMonitor/MM_psDQ_Out/MM_psDQ_Out.cc
@@ -49,10 +49,10 @@ QueueData::QueueData(){
 
 
 void MM_psDQ_Out::initialize() {
-    defaultPriority = par("defPriority").longValue();
+    defaultPriority = par("defPriority");
     if(defaultPriority < 0) { error("Error at eDL_Out. defPriority must be >=0!"); }
 
-    int rateUnit = par("rateUnit").longValue();
+    int rateUnit = par("rateUnit");
     if(defaultPriority < 0) { error("Error at eDL_Out. defPriority must be >=0!"); }
 
     maxPriority = defaultPriority;

--- a/policies/DIF/RMT/Monitor/TKMonitor/TKMonitor.cc
+++ b/policies/DIF/RMT/Monitor/TKMonitor/TKMonitor.cc
@@ -87,7 +87,7 @@ void TKMonitor::onPolicyInit(){
         TKs[inf.id] = inf;
     }
 
-    tokensPDU = par("tokensPDU").longValue();
+    tokensPDU = par("tokensPDU");
 }
 
 void TKMonitor::postPDUInsertion(RMTQueue* queue) {

--- a/policies/DIF/RMT/Monitor/WeightedFairQMonitor/WeightedFairQMonitor.cc
+++ b/policies/DIF/RMT/Monitor/WeightedFairQMonitor/WeightedFairQMonitor.cc
@@ -25,11 +25,11 @@ using namespace std;
 
 void WeightedFairQMonitor::onPolicyInit(){
     // Default Bandwith for Queues not linked to flows or with undefined bandwith
-    defBW = par("defBW").longValue();
+    defBW = par("defBW");
 
     // Queue sizes for lock and release EFCPi
-    stopQAt = par("stopQAt").longValue();
-    startQAt = par("startQAt").longValue();
+    stopQAt = par("stopQAt");
+    startQAt = par("startQAt");
 }
 
 void WeightedFairQMonitor::postQueueCreation(RMTQueue* queue){

--- a/policies/DIF/RMT/PDUForwarding/GREFWD/GREFWD.cc
+++ b/policies/DIF/RMT/PDUForwarding/GREFWD/GREFWD.cc
@@ -31,7 +31,7 @@ vPorts GREFWD::lookup(const PDU * pdu) {
 
     PDU * pd = const_cast<PDU*>(pdu);
     auto hc = pd->getHopCount();
-    if(hc <= par("TTL").longValue()) {
+    if(hc <= static_cast<long>(par("TTL"))) {
         cout << "Over TTL"<<endl;
         return ret;
     }

--- a/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Edge/SimpleEdgeForwarding.cc
+++ b/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Edge/SimpleEdgeForwarding.cc
@@ -34,7 +34,7 @@ namespace NSPSimpleDC {
 
 
     void SimpleEdgeForwarding::onPolicyInit() {
-        downCount = par("downCount").longValue();
+        downCount = par("downCount");
         if(downCount < 0) { downCount = 0; }
         portsArray = new Port[downCount];
         for(int i = 0; i<downCount; i++) { portsArray[i] = nullptr; }

--- a/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Fabric/SimpleFabricForwarding.cc
+++ b/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Fabric/SimpleFabricForwarding.cc
@@ -33,10 +33,10 @@ namespace NSPSimpleDC {
     fFWDEntry::fFWDEntry() : entryType(0), inverseStorage(false) {}
 
     void SimpleFabricForwarding::onPolicyInit() {
-        upCount = par("upCount").longValue();
+        upCount = par("upCount");
         if(upCount < 0) { upCount = 0; }
 
-        downCount = par("downCount").longValue();
+        downCount = par("downCount");
         if(downCount < 0) { downCount = 0; }
 
         portsArray = new Port[upCount+downCount];

--- a/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Spine/SimpleSpineForwarding.cc
+++ b/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/Spine/SimpleSpineForwarding.cc
@@ -34,10 +34,10 @@ namespace NSPSimpleDC {
 
 
     void SimpleSpineForwarding::onPolicyInit() {
-        upCount = par("upCount").longValue();
+        upCount = par("upCount");
         if(upCount < 0) { upCount = 0; }
 
-        downCount = par("downCount").longValue();
+        downCount = par("downCount");
         if(downCount < 0) { downCount = 0; }
 
         portsArray = new Port[upCount+downCount];

--- a/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/TOR/SimpleTORForwarding.cc
+++ b/policies/DIF/RMT/PDUForwarding/SimpleDCForwarding/TOR/SimpleTORForwarding.cc
@@ -34,7 +34,7 @@ namespace NSPSimpleDC {
 
 
     void SimpleTORForwarding::onPolicyInit() {
-        upCount = par("upCount").longValue();
+        upCount = par("upCount");
         if(upCount < 0) { upCount = 0; }
         portsArray = new Port[upCount];
         for(int i = 0; i<upCount; i++) { portsArray[i] = nullptr; }

--- a/policies/DIF/RMT/Scheduler/RMTSchedulingBase.cc
+++ b/policies/DIF/RMT/Scheduler/RMTSchedulingBase.cc
@@ -36,7 +36,7 @@ void RMTSchedulingBase::handleMessage(cMessage *msg)
 {
     if (msg->isSelfMessage() && !opp_strcmp(msg->getFullName(), "processPort"))
     { // TODO: this is lousy, think of something better
-        RMTQueueType direction = (RMTQueueType)msg->par("direction").longValue();
+        RMTQueueType direction = static_cast<RMTQueueType>(static_cast<long>(msg->par("direction")));
         const char* portName = msg->par("portName").stringValue();
         RMTPort* port = rmtAllocator->getPort(portName);
         if (port != NULL)
@@ -65,7 +65,7 @@ void RMTSchedulingBase::scheduleReinvocation(simtime_t time, RMTPort* port, RMTQ
     msg->par("portName").setStringValue(port->getParentModule()->getFullName());
 
     msg->addPar("direction");
-    msg->par("direction").setLongValue(direction);
+    msg->par("direction") = direction;
 
     scheduleAt(time, msg);
 }

--- a/policies/DIF/Routing/CentralRouting/RoutingManager.cc
+++ b/policies/DIF/Routing/CentralRouting/RoutingManager.cc
@@ -34,10 +34,10 @@ void RoutingManager::onPolicyInit() {
     if(start_Time < 0.0) { start_Time = 0.0; }
     scheduleAt(simTime() + start_Time, start_timer);
 
-    f = par("fabrics").longValue();
-    p = par("pods").longValue();
-    s = par("spines").longValue();
-    t = par("tors").longValue();
+    f = par("fabrics");
+    p = par("pods");
+    s = par("spines");
+    t = par("tors");
 
     current_sent = 0;
     exception_in_seq = 0;

--- a/policies/DIF/Routing/DCRouting/IntDCRouting.cc
+++ b/policies/DIF/Routing/DCRouting/IntDCRouting.cc
@@ -143,11 +143,11 @@ namespace NSPSimpleDC {
         start = new cMessage("Start updates");
         sched = nullptr;
 
-        pods = par("pods").longValue();
-        torXpod = par("torXpod").longValue();
-        fabricXpod = par("fabricXpod").longValue();
-        spineXfabric = par("spineXfabric").longValue();
-        edgeSets = par("edgeSets").longValue();
+        pods = par("pods");
+        torXpod = par("torXpod");
+        fabricXpod = par("fabricXpod");
+        spineXfabric = par("spineXfabric");
+        edgeSets = par("edgeSets");
         updateWait = par("updateWait").doubleValue();
         expiration = par("expiration").doubleValue();
         double starttime = par("starttime").doubleValue();

--- a/policies/DIF/Routing/SimpleRouting/SimpleDV/SimpleDV.cc
+++ b/policies/DIF/Routing/SimpleRouting/SimpleDV/SimpleDV.cc
@@ -205,7 +205,7 @@ void SimpleDV::onPolicyInit(){
         myAddr = myAddress.getIpcAddress().getName();
     }
 
-    infMetric = par("infMetric").longValue();
+    infMetric = par("infMetric");
 
     scheduledUpdate = false;
     scheduleUpdate();

--- a/policies/DIF/Routing/SimpleRouting/SimpleLS/SimpleLS.cc
+++ b/policies/DIF/Routing/SimpleRouting/SimpleLS/SimpleLS.cc
@@ -230,7 +230,7 @@ void SimpleLS::onPolicyInit(){
         myAddr = myAddress.getIpcAddress().getName();
     }
 
-    infMetric = par("infMetric").longValue();
+    infMetric = par("infMetric");
     secId = 1;
 }
 

--- a/policies/makefrag
+++ b/policies/makefrag
@@ -1,1 +1,1 @@
-CXXFLAGS=-std=c++11 -Wall -Wno-deprecated-declarations -DAUTOIMPORT_OMNETPP_NAMESPACE -DAUTOIMPORT_OMNETPP_NAMESPACE
+CXXFLAGS=-std=c++17 -Wall -Wextra -Wno-deprecated-declarations -Wno-inconsistent-missing-override -DAUTOIMPORT_OMNETPP_NAMESPACE

--- a/src/Addons/Actions/FailureSimulation/FailureSimulation.cc
+++ b/src/Addons/Actions/FailureSimulation/FailureSimulation.cc
@@ -10,7 +10,7 @@ void FailureSimulation::initialize() {
     killTimer = new cMessage("Kill Time");
     resurrectTimer = new cMessage("Resurrect Time");
 
-    c = par("amount").longValue();
+    c = par("amount");
     double tK = par("killAt").doubleValue();
     double tR = par("resurrectAt").doubleValue();
     interKill = par("interKill").doubleValue();

--- a/src/Addons/Channels/EthChannel/EthChannel.cc
+++ b/src/Addons/Channels/EthChannel/EthChannel.cc
@@ -7,8 +7,8 @@ EthChannel::EthChannel() : cDatarateChannel() {
 }
 void EthChannel::initialize() {
     cDatarateChannel::initialize();
-    eheader = par("header").longValue();
-    eipg = par("ipg").longValue();
+    eheader = par("header");
+    eipg = par("ipg");
     edelay = par("delay").doubleValue();
     edatarate = par("datarate").doubleValue()/8.0;
     etxfinishtime = 0.0;

--- a/src/Addons/DataInjectors/FlowsSimulation/Implementations/VDT/VDT.cc
+++ b/src/Addons/DataInjectors/FlowsSimulation/Implementations/VDT/VDT.cc
@@ -73,8 +73,8 @@ void VDT::handleMessage(cMessage *msg) {
 void VDT::postInitialize() {
 // Voice parameters initialization
     V_QOS = par("V_QOS").stdstringValue();
-    V_PDUSize_min = par("V_PDUSize_min").longValue();
-    V_PDUSize_max = par("V_PDUSize_max").longValue();
+    V_PDUSize_min = par("V_PDUSize_min");
+    V_PDUSize_max = par("V_PDUSize_max");
     V_AVG_FlowRate = par("V_AVG_FlowRate").doubleValue()*1000.0/8.0;
     V_ON_Duration_AVG = par("V_ON_Duration_AVG").doubleValue();
     V_ON_Duration_VAR = par("V_ON_Duration_VAR").doubleValue();
@@ -86,8 +86,8 @@ void VDT::postInitialize() {
 
 // Data request parameters initialization
     D_QOS = par("D_QOS").stdstringValue();
-    D_Request_PDUSize = par("D_Request_PDUSize").longValue();
-    D_Data_PDUSize = par("D_Data_PDUSize").longValue();
+    D_Request_PDUSize = par("D_Request_PDUSize");
+    D_Data_PDUSize = par("D_Data_PDUSize");
     D_AVG_FlowRate = par("D_AVG_FlowRate").doubleValue()*1000.0/8.0;
     D_ON_FlowRate = par("D_ON_FlowRate").doubleValue()*1000.0/8.0;
     D_OFF_Duration_AVG = par("D_OFF_Duration_AVG").doubleValue();
@@ -98,11 +98,11 @@ void VDT::postInitialize() {
 
 // Transfer parameters initialization
     T_QOS = par("T_QOS").stdstringValue();
-    T_Request_PDUSize = par("T_Request_PDUSize").longValue();
-    T_Data_PDUSize = par("T_Data_PDUSize").longValue();
+    T_Request_PDUSize = par("T_Request_PDUSize");
+    T_Data_PDUSize = par("T_Data_PDUSize");
     T_AVG_FlowRate = par("T_AVG_FlowRate").doubleValue()*1000.0/8.0;
-    T_WINDOW_MAX = par("T_WINDOW_MAX").longValue();
-    T_WINDOW_UPDATE = par("T_WINDOW_UPDATE").longValue();
+    T_WINDOW_MAX = par("T_WINDOW_MAX");
+    T_WINDOW_UPDATE = par("T_WINDOW_UPDATE");
     T_Interval = T_Data_PDUSize / T_AVG_FlowRate;
 
 

--- a/src/Addons/DataInjectors/FlowsSimulation/Inj_t.cc
+++ b/src/Addons/DataInjectors/FlowsSimulation/Inj_t.cc
@@ -56,7 +56,7 @@ void Inj_t::initialize() {
     dstAddr = Address("", dif.c_str());
     connID.setDstCepId(-1);
 
-    headers = par("headers_size").longValue();
+    headers = par("headers_size");
 
     pduId = 0;
 

--- a/src/Addons/DataInjectors/ReachabilityTest/ReachabilityTest.cc
+++ b/src/Addons/DataInjectors/ReachabilityTest/ReachabilityTest.cc
@@ -53,7 +53,7 @@ void ReachabilityTest::initialize() {
     dstAddr = Address("", dif.c_str());
     connID.setDstCepId(-1);
     QoS = par("QoS").stdstringValue();
-    header = par("header_size").longValue();
+    header = par("header_size");
 
     string nodes_raw = par("nodes").stdstringValue();
     split(nodes_raw, ' ', remaining);

--- a/src/DAF/AE/AEMonitor/AEMonitor.cc
+++ b/src/DAF/AE/AEMonitor/AEMonitor.cc
@@ -45,7 +45,7 @@ bool AEMonitor::onA_read(APIReqObj* obj) {
     object.objectInstance = -1;
     object.objectVal = NULL;
     ping->setObjectItem(object);
-    ping->setByteLength((int)par("size").longValue());
+    ping->setByteLength((int)par("size"));
 
     //Send message
     sendData(FlowObject, ping);
@@ -56,7 +56,7 @@ bool AEMonitor::onA_read(APIReqObj* obj) {
 bool AEMonitor::onA_write(APIReqObj* obj) {
     CDAP_M_Write* write = new CDAP_M_Write("M_WRITE(stream)");
     write->setObjectItem(*obj->getObj());
-    write->setByteLength((int)par("size").longValue());
+    write->setByteLength((int)par("size"));
 
     //Send message
     sendData(FlowObject, write);
@@ -76,7 +76,7 @@ void AEMonitor::processMRead(CDAPMessage* msg) {
         object.objectInstance = -1;
         object.objectVal = (cObject*)(objPing.objectVal);
         pong->setObjectItem(object);
-        pong->setByteLength((int)par("size").longValue());
+        pong->setByteLength((int)par("size"));
 
         //inc object val
         objPing.objectVal += 1;

--- a/src/DAF/AEManagement/AEMgmtBase.cc
+++ b/src/DAF/AEManagement/AEMgmtBase.cc
@@ -44,7 +44,8 @@ void AEMgmtBase::initMyAddress() {
 }
 
 long AEMgmtBase::getNewInvokeId() {
-    long newinvoke = getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID).longValue() + 1;
+    long newinvoke =
+        static_cast<long>(getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID)) + 1;
     getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID) = newinvoke;
     return newinvoke;
 }

--- a/src/DAF/AP/APPing/APPing.cc
+++ b/src/DAF/AP/APPing/APPing.cc
@@ -33,8 +33,8 @@ APPing::~APPing() {
 void APPing::initialize() {
     AP::initialize();
     currentID = 0;
-    long t1 = par("startAt").longValue();
-    long t2 = par("stopAt").longValue();
+    double t1 = static_cast<double>(par("startAt"));
+    double t2 = static_cast<double>(par("stopAt"));
 
     if (strcmp(par("dstApName").stringValue(),"AppERROR") &&
             t2 > t1 && t1 > 0 && t2 > 0
@@ -101,7 +101,7 @@ void APPing::handleMessage(cMessage *msg) {
 
         }
         else if (!strcmp(msg->getName(), "ping")) {
-            if ((simTime().dbl()+1) < par("stopAt").doubleValue() ) {
+            if ((simTime().dbl()+1) < static_cast<double>(par("stopAt")) ) {
                 connID = conIDsPing.front();
                 conIDsPing.pop();
 

--- a/src/DAF/AP/APPing/APPing.ned
+++ b/src/DAF/AP/APPing/APPing.ned
@@ -29,10 +29,10 @@ simple APPing extends AP like APInst
 {
     parameters:
         @class(APPing);
-        
-        int startAt @unit(s) = default(-1s);
-        int stopAt  @unit(s) = default(-1s);
-        int pingAt  @unit(s) = default(0s);
+
+        double startAt @unit(s) = default(-1s);
+        double stopAt  @unit(s) = default(-1s);
+        double pingAt  @unit(s) = default(0s);
         double interval @unit(s) = default(1s);
 
         string dstApName = default("AppERROR");

--- a/src/DAF/AP/APStream/APStream.cc
+++ b/src/DAF/AP/APStream/APStream.cc
@@ -28,10 +28,10 @@ void APStream::initialize() {
     AP::initialize();
     if (strcmp(par("dstApName").stringValue(),"AppErr")) {
         m1 = new cMessage("start");
-        scheduleAt(simTime() + par("startAt").longValue(), m1);
+        scheduleAt(simTime() + static_cast<double>(par("startAt")), m1);
 
         m2 = new cMessage("stop");
-        scheduleAt(simTime() + par("stopAt").longValue(), m2);
+        scheduleAt(simTime() + static_cast<double>(par("stopAt")), m2);
     }
 }
 
@@ -45,7 +45,7 @@ void APStream::handleMessage(cMessage *msg) {
             a_close(conID);
         }
         else if (!strcmp(msg->getName(), "stream")){
-            if ((simTime().dbl()+1) < par("stopAt").doubleValue()) {
+            if ((simTime().dbl()+1) < static_cast<double>(par("stopAt"))) {
                 object_t obj;
                 obj.objectName = "stream";
                 obj.objectVal = (cObject*)"tmp";

--- a/src/DAF/AP/APStream/APStream.ned
+++ b/src/DAF/AP/APStream/APStream.ned
@@ -29,14 +29,14 @@ simple APStream extends AP like APInst
 {
     parameters:
         @class(APStream);
-        
-        int startAt @unit(s) = default(0s);
-        int stopAt  @unit(s) = default(0s);
+
+        double startAt @unit(s) = default(0s);
+        double stopAt  @unit(s) = default(0s);
         double interval @unit(s) = default(0.1s);
-        
+
 
         string dstApName = default("AppErr");
-        
+
 }
 
 

--- a/src/DAF/DA/DA.cc
+++ b/src/DAF/DA/DA.cc
@@ -93,7 +93,7 @@ void DA::initialize()
 bool DA::isDifLocalToIpc(const std::string difName, cModule* ipc) {
     cModule* top = ipc->getParentModule();
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule *submodp = j();
+        cModule *submodp = *j;
         if (isIpcXLocalToIpcY(submodp, ipc)
                 && !opp_strcmp(submodp->par(PAR_DIFNAME), difName.c_str())                    //...has a given DIF name
            )
@@ -119,7 +119,7 @@ bool DA::isIpcXLocalToIpcY(cModule* ipcX, cModule* ipcY) {
 bool DA::isAppLocal(const APN& apn) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule* submodp = j();
+        cModule* submodp = *j;
         if ( (submodp->hasPar(PAR_APNAME)
                 && !opp_strcmp(submodp->par(PAR_APNAME), apn.getName().c_str() ) )
 //             ||
@@ -134,7 +134,7 @@ bool DA::isAppLocal(const APN& apn) {
 bool DA::isDifLocal(const DAP& difName) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule* submodp = j();
+        cModule* submodp = *j;
         if (submodp->hasPar(PAR_DIFNAME)
             && !opp_strcmp(submodp->par(PAR_DIFNAME), difName.getName().c_str())
            ) {
@@ -148,7 +148,7 @@ bool DA::isDifLocal(const DAP& difName) {
 bool DA::isIpcLocal(cModule* ipc) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule* submodp = j();
+        cModule* submodp = *j;
         if (submodp == ipc)
             return true;
     }
@@ -158,7 +158,7 @@ bool DA::isIpcLocal(cModule* ipc) {
 cModule* DA::getDifMember(const DAP& difName) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule* submodp = j();
+        cModule* submodp = *j;
         if (submodp->hasPar(PAR_DIFNAME)
             && !opp_strcmp(submodp->par(PAR_DIFNAME), difName.getName().c_str())
            )
@@ -170,7 +170,7 @@ cModule* DA::getDifMember(const DAP& difName) {
 cModule* DA::findIpc(const Address& addr) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule *submodp = j();
+        cModule *submodp = *j;
         if (submodp->hasPar(PAR_IPCADDR) && submodp->hasPar(PAR_DIFNAME)) {
             Address adr = Address(submodp->par(PAR_IPCADDR), submodp->par(PAR_DIFNAME));
             if (adr == addr)
@@ -204,7 +204,7 @@ void DA::handleMessage(cMessage *msg)
 cModule* DA::findApp(const APN& apn) {
     cModule* top = this->getModuleByPath("^.^");
     for (cModule::SubmoduleIterator j(top); !j.end(); j++) {
-        cModule *submodp = j();
+        cModule *submodp = *j;
         if (submodp->hasPar(PAR_APNAME) && !strcmp(submodp->par(PAR_APNAME), apn.getName().c_str()) ) {
             return submodp;
         }

--- a/src/DAF/RIB/DAFRIBdBase.cc
+++ b/src/DAF/RIB/DAFRIBdBase.cc
@@ -29,7 +29,8 @@ DAFRIBdBase::~DAFRIBdBase() {
 }
 
 long DAFRIBdBase::getNewInvokeId() {
-    long newinvoke = getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID).longValue() + 1;
+    long newinvoke =
+        static_cast<long>(getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID)) + 1;
     getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID) = newinvoke;
     return newinvoke;
 }

--- a/src/DIF/RIB/RIBdBase.cc
+++ b/src/DIF/RIB/RIBdBase.cc
@@ -46,7 +46,8 @@ void RIBdBase::initMyAddress() {
 }
 
 long RIBdBase::getNewInvokeId() {
-    long newinvoke = getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID).longValue() + 1;
+    long newinvoke =
+        static_cast<long>(getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID)) + 1;
     getParentModule()->getSubmodule(MOD_CDAP)->par(PAR_CURINVOKEID) = newinvoke;
     return newinvoke;
 }

--- a/src/makefrag
+++ b/src/makefrag
@@ -1,1 +1,6 @@
-CXXFLAGS=-std=c++11 -Wall -Wno-deprecated-declarations -DAUTOIMPORT_OMNETPP_NAMESPACE 
+CXXFLAGS=-std=c++17 -Wall -Wextra -Wno-deprecated-declarations -Wno-inconsistent-missing-override -DAUTOIMPORT_OMNETPP_NAMESPACE
+
+#
+# Use the older message compiler. New compiler was introduced in OMNeT++ 5.3
+#
+MSGC:=$(MSGC) --msg4


### PR DESCRIPTION
As of OMNeT++ 5.3, a new message compiler was introduced. The legacy message compiler is still used by default in OMNeT++ 5, but for compatibility with future versions I have explicitly set the msg4 option, which enables the legacy message compiler. Also updated to C++17. Literally no reason to use C++11.

Implicit casts are now preferred over the use of `.longValue()` for `cPar`. You can see why under features introduced in 5.3:
https://doc.omnetpp.org/omnetpp/api/APIChanges.html
`.longValue()` is replaced by `.intValue()` in OMNeT++ 6, so casting is the better option anyway in regards to compatibility.

`SubmoduleIterator` uses `*` instead of `()` as an access operator now.
https://doc.omnetpp.org/omnetpp/api/classomnetpp_1_1cModule_1_1SubmoduleIterator.html

From https://github.com/karlhto/RINA-thesis originally, which was a private bare clone of this repo. Check it for original commit dates if wanted.